### PR TITLE
Tweak implementation on exercise 3.10 with bytes.Buffer

### DIFF
--- a/ch03/ex3.10/ex3.10.go
+++ b/ch03/ex3.10/ex3.10.go
@@ -16,17 +16,17 @@ func main() {
 func comma(s string) string {
 	// Set the buffer with it 0 value
 	var buff bytes.Buffer
-	// Use this remainder for get the number of digits behind
+	// Number of digits before needing a comma
 	remainder := len(s) % 3
 
 	for i, v := range s {
-		// Print just the value if isn't a multiple of 3 after the reminder
+		// Write just the value if isn't a multiple of 3 after the reminder
 		if i < remainder || !((i-remainder)%3 == 0 && i != 0) {
 			_, _ = fmt.Fprintf(&buff, "%c", v)
 			continue
 		}
 
-		// Write a comma is it, then just print the rune
+		// Write a comma each 3 digits, then just write the rune
 		buff.WriteByte(',')
 		_, _ = fmt.Fprintf(&buff, "%c", v)
 	}

--- a/ch03/ex3.10/ex3.10.go
+++ b/ch03/ex3.10/ex3.10.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 )
@@ -11,17 +12,24 @@ func main() {
 	}
 }
 
-// comma inserts commas in a non-negative decimal integer string.
+// Comma inserts commas in a non-negative decimal integer string.
 func comma(s string) string {
-	n := len(s)
-	i := n % 3
-	if i == 0 {
-		i += 3
+	// Set the buffer with it 0 value
+	var buff bytes.Buffer
+	// Use this remainder for get the number of digits behind
+	remainder := len(s) % 3
+
+	for i, v := range s {
+		// Print just the value if isn't a multiple of 3 after the reminder
+		if i < remainder || !((i-remainder)%3 == 0 && i != 0) {
+			_, _ = fmt.Fprintf(&buff, "%c", v)
+			continue
+		}
+
+		// Write a comma is it, then just print the rune
+		buff.WriteByte(',')
+		_, _ = fmt.Fprintf(&buff, "%c", v)
 	}
-	for i < n {
-		s = s[:i] + "," + s[i:]
-		i += 4
-		n++
-	}
-	return s
+
+	return buff.String()
 }


### PR DESCRIPTION
As the statement says, it would be more appropriate to use bytes.Buffer instead of strings. This is kinda lame, but I think it is necessary.